### PR TITLE
Add feature to link libelf and zlib statically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ crate-type = ["lib", "staticlib"]
 
 [features]
 novendor = []
+static = []

--- a/build.rs
+++ b/build.rs
@@ -83,6 +83,16 @@ fn generate_bindings(src_dir: path::PathBuf) {
 #[cfg(not(feature = "bindgen"))]
 fn generate_bindings(_: path::PathBuf) {}
 
+#[cfg(feature = "static")]
+fn library_prefix() -> String {
+    "static=".to_string()
+}
+
+#[cfg(not(feature = "static"))]
+fn library_prefix() -> String {
+    "".to_string()
+}
+
 fn main() {
     let src_dir = path::PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let out_dir = path::PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -166,14 +176,15 @@ fn main() {
             .unwrap();
         io::stdout().write_all("\n".as_bytes()).unwrap();
         io::stdout()
-            .write_all("cargo:rustc-link-lib=elf\n".as_bytes())
+            .write_all(format!("cargo:rustc-link-lib={}elf\n", library_prefix()).as_bytes())
             .unwrap();
         io::stdout()
-            .write_all("cargo:rustc-link-lib=z\n".as_bytes())
+            .write_all(format!("cargo:rustc-link-lib={}z\n", library_prefix()).as_bytes())
             .unwrap();
         io::stdout()
             .write_all("cargo:rustc-link-lib=static=bpf\n".as_bytes())
             .unwrap();
+
         io::stdout().write_all("cargo:include=".as_bytes()).unwrap();
         io::stdout()
             .write_all(out_dir.as_os_str().as_bytes())


### PR DESCRIPTION
## Context
Applications that use libbpf-rs dynamically link libelf and zlib through libbpf-sys. It can be desirable to produce binaries that are statically linked, or that at least reduce the number of dependencies loaded at runtime for distribution reasons.

This is exactly [rbperf](https://github.com/javierhonduco/rbperf/)'s, situation, and I imagine this also affects a number of other applications where it would be fantastic to be able to run it in systems with the fewest amount of required dynamic libraries.

## Follow-ups
If this PR gets merged, we could bump its version and release it. Once that's done, I will update push https://github.com/javierhonduco/libbpf-rs/commit/b66a96e6214cbb79e87fc17296ee4c1d66d6c5db with a test to ensure that libelf and zlib are statically linked when the feature is enabled.

If / when libbpf's offers static linking in its build in the future, such as @anakryiko suggested in https://github.com/libbpf/libbpf-sys/issues/40, I would be happy to create another PR to pass the right flags to its build


## Test plan
**Before**
```
[javierhonduco@computer-2 rbperf]$ ldd target/debug/rbperf
	linux-vdso.so.1 (0x00007ffca76d3000)
	libelf.so.1 => /lib/libelf.so.1 (0x00007fbfb7f5a000)
	libz.so.1 => /lib64/libz.so.1 (0x00007fbfb7f40000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fbfb7f20000)
	libm.so.6 => /lib64/libm.so.6 (0x00007fbfb7e42000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fbfb7c41000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fbfb87cf000)
```

**After**
```
[javierhonduco@computer rbperf]$ ldd target/debug/rbperf
	linux-vdso.so.1 (0x00007ffde392c000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f6dd42ff000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f6dd4221000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f6dd4020000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f6dd4ba0000)
```