### PR TITLE
Fix broken novendor feature

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -94,6 +94,9 @@ fn main() {
     generate_bindings(src_dir.clone());
 
     if cfg!(feature = "novendor") {
+        io::stdout()
+            .write_all(format!("cargo:rustc-link-lib={}bpf\n", library_prefix()).as_bytes())
+            .unwrap();
         return;
     }
 

--- a/build.rs
+++ b/build.rs
@@ -94,9 +94,7 @@ fn main() {
     generate_bindings(src_dir.clone());
 
     if cfg!(feature = "novendor") {
-        io::stdout()
-            .write_all(format!("cargo:rustc-link-lib={}bpf\n", library_prefix()).as_bytes())
-            .unwrap();
+        println!("cargo:rustc-link-lib={}bpf\n", library_prefix());
         return;
     }
 
@@ -144,26 +142,9 @@ fn main() {
 
     assert!(status.success(), "make failed");
 
-    io::stdout()
-        .write_all("cargo:rustc-link-search=native=".as_bytes())
-        .unwrap();
-    io::stdout()
-        .write_all(out_dir.as_os_str().as_bytes())
-        .unwrap();
-    io::stdout().write_all("\n".as_bytes()).unwrap();
-    io::stdout()
-        .write_all(format!("cargo:rustc-link-lib={}elf\n", library_prefix()).as_bytes())
-        .unwrap();
-    io::stdout()
-        .write_all(format!("cargo:rustc-link-lib={}z\n", library_prefix()).as_bytes())
-        .unwrap();
-    io::stdout()
-        .write_all("cargo:rustc-link-lib=static=bpf\n".as_bytes())
-        .unwrap();
-
-    io::stdout().write_all("cargo:include=".as_bytes()).unwrap();
-    io::stdout()
-        .write_all(out_dir.as_os_str().as_bytes())
-        .unwrap();
-    io::stdout().write_all("/include\n".as_bytes()).unwrap();
+    println!("cargo:rustc-link-search=native={}", out_dir.to_string_lossy());
+    println!("cargo:rustc-link-lib={}elf", library_prefix());
+    println!("cargo:rustc-link-lib={}z", library_prefix());
+    println!("cargo:rustc-link-lib=static=bpf");
+    println!("cargo:include={}/include", out_dir.to_string_lossy());
 }


### PR DESCRIPTION
    $ cargo test --features novendor

      = note: /usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: target/debug/deps/tests-81d77a8d8e24cc4f.v49whvrqu4l5awr.rcgu.o: in function `tests::tests::test':
              tests/tests.rs:19: undefined reference to `libbpf_set_print'
              collect2: error: ld returned 1 exit status

      = help: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
      = note: use the `-l` flag to specify native libraries to link
      = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)