### PR TITLE
Configure CI to build on multiple architectures, glibc and musl, default features and novendor & add release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,122 @@
+name: CI
+on:
+  - push
+  - pull_request
+
+jobs:
+  test-gnu:
+    # dynamically linked glibc
+    name: Test on Ubuntu ${{ matrix.os-arch }} (${{ matrix.features }})
+    strategy:
+      matrix:
+        include:
+          - rust-target: x86_64-unknown-linux-gnu
+            os-target: x86_64-linux-gnu
+            os-arch: amd64
+            features: ''
+
+          - rust-target: x86_64-unknown-linux-gnu
+            os-target: x86_64-linux-gnu
+            os-arch: amd64
+            features: novendor
+
+          - rust-target: aarch64-unknown-linux-gnu
+            os-target: aarch64-linux-gnu
+            os-arch: arm64
+            features: ''
+
+          - rust-target: powerpc64le-unknown-linux-gnu
+            os-target: powerpc64le-linux-gnu
+            os-arch: ppc64el
+            features: ''
+    runs-on: ubuntu-latest
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.rust-target }}
+      CARGO_TERM_VERBOSE: 'true'
+      RUSTFLAGS: -C linker=/usr/bin/${{ matrix.os-target }}-gcc
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Add apt sources for ${{ matrix.os-arch }}
+        if: matrix.os-arch != 'amd64'
+        run: |
+          dpkg --add-architecture ${{ matrix.os-arch }}
+
+          release=$(. /etc/os-release && echo "$UBUNTU_CODENAME")
+          sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list
+          printf 'deb [arch=${{ matrix.os-arch }}] http://ports.ubuntu.com/ %s main restricted\n' \
+              $release $release-updates $release-security \
+              >> /etc/apt/sources.list
+        shell: sudo sh -e {0}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+              build-essential \
+              libelf-dev:${{ matrix.os-arch }} \
+              linux-headers-generic:${{ matrix.os-arch }} \
+              zlib1g-dev:${{ matrix.os-arch }}
+
+      - name: Install libbpf-dev
+        if: matrix.features == 'novendor'
+        run: sudo apt-get install libbpf-dev:${{ matrix.os-arch }}
+
+      - name: Install linker for ${{ matrix.os-target }}
+        if: matrix.os-arch != 'amd64'
+        run: sudo apt-get install gcc-${{ matrix.os-target }}
+
+      - name: Install Rust stable for ${{ matrix.rust-target }}
+        uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          profile: minimal
+          target: ${{ matrix.rust-target }}
+          toolchain: stable
+
+      - run: cargo build --features "${{ matrix.features }}"
+
+      - run: cargo test --features "${{ matrix.features }}"
+        if: matrix.os-arch == 'amd64'
+
+  test-musl:
+    # dynamically linked musl libc
+    name: Test on Alpine Linux x86_64 (${{ matrix.features }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - ''
+          - novendor
+    env:
+      CARGO_TERM_VERBOSE: 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Alpine Linux with dependencies
+        uses: jirutka/setup-alpine@v1
+        with:
+          branch: latest-stable
+          packages: >
+            build-base
+            cargo
+            elfutils-dev
+            linux-headers
+            zlib-dev
+
+      - name: Install libbpf-dev
+        if: matrix.features == 'novendor'
+        run: apk add libbpf-dev
+        shell: alpine.sh --root {0}
+
+      - run: cargo build --features "${{ matrix.features }}"
+        shell: alpine.sh {0}
+
+      - run: cargo test --features "${{ matrix.features }}"
+        shell: alpine.sh {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,43 @@ jobs:
 
       - run: cargo test --features "${{ matrix.features }}"
         shell: alpine.sh {0}
+
+  publish:
+    name: Publish to crates.io
+    if: github.ref_type == 'tag' && github.event_name != 'pull_request'
+    needs:
+      - test-gnu
+      - test-musl
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          profile: minimal
+          toolchain: stable
+
+      # This is needed for cargo-pkgid.
+      - name: Fetch dependencies and generate Cargo.lock
+        run: cargo fetch
+
+      - name: Resolve crate version and check git tag name
+        run: |
+          crate_version="$(cargo pkgid | cut -d '#' -f2 | grep -o '[^:]*$')"
+          git_tag=${GITHUB_REF#refs/tags/}
+
+          if [ "$git_tag" != "$crate_version" ]; then
+              printf '::error::%s\n' "Crate version ($crate_version) does not match git tag ($git_tag)"
+              exit 1
+          fi
+
+      - name: Publish to crates.io
+        # no-verify is to skip building; it has been already verified in the test-* jobs.
+        run: cargo publish --no-verify --verbose
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-os: linux
-dist: bionic
-
-language: rust
-rust:
-  - stable
-
-before_install:
-  - sudo apt-get -y install curl build-essential linux-headers-generic zlib1g-dev libelf-dev libclang-dev llvm clang

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ build = "build.rs"
 links = "libbpf"
 
 [badges]
-travis-ci = { repository = "libbpf/libbpf-sys" }
+github = { repository = "libbpf/libbpf-sys" }
 maintenance = { status = "passively-maintained" }
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# libbpf-sys [![Travis CI build status badge](https://app.travis-ci.com/libbpf/libbpf-sys.svg?branch=master)](https://app.travis-ci.com/libbpf/libbpf-sys) [![crates.io version number badge](https://img.shields.io/crates/v/libbpf-sys.svg)](https://crates.io/crates/libbpf-sys)
+# libbpf-sys [![Build status](https://github.com/libbpf/libbpf-sys/workflows/CI/badge.svg)](https://github.com/libbpf/libbpf-sys/actions?query=workflow%3A%22CI%22) [![crates.io version number badge](https://img.shields.io/crates/v/libbpf-sys.svg)](https://crates.io/crates/libbpf-sys)
 
 **Rust bindings to _libbpf_ from the Linux kernel**
 


### PR DESCRIPTION
### Replace Travis CI with GitHub Actions

The new CI workflow builds libbpf-sys on multiple CPU architectures, glibc and musl, default features and novendor feature.

### Add Release workflow

This workflow runs when a new release tag is pushed to the repository
and publishes the crate to crates.io.

To make it work, it's needed to create a new API token on https://crates.io/settings/tokens and add it as a secret variable `CARGO_REGISTRY_TOKEN` on https://github.com/libbpf/libbpf-sys/settings/secrets/actions.

* * *
Demo: https://github.com/jirutka/libbpf-sys/actions/runs/3253306378