### PR TITLE
Support LD_LIBRARY_PATH

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -147,4 +147,10 @@ fn main() {
     println!("cargo:rustc-link-lib={}z", library_prefix());
     println!("cargo:rustc-link-lib=static=bpf");
     println!("cargo:include={}/include", out_dir.to_string_lossy());
+
+    if let Ok(ld_path) = env::var("LD_LIBRARY_PATH") {
+        for path in ld_path.split(":") {
+            println!("cargo:rustc-link-search=native={}", path);
+        }
+    }
 }


### PR DESCRIPTION
This helps dependent crates to use `LD_LIBRARY_PATH` for statically linking `libelf` and `libz` from various directories.

Refers to #49 