### PR TITLE
CI: test building libbpf-rs with libbpf-sys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,41 @@ jobs:
       - run: cargo test --features "${{ matrix.features }}"
         shell: alpine.sh {0}
 
+  test-libbpf-rs:
+    # check that libbpf-rs, one of the main consumers of the library, works with
+    # this version of libbpf-sys
+    name: Test libbpf-rs integration
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_VERBOSE: 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+              build-essential \
+              libelf-dev
+
+      - name: Build libbpf-rs with libbpf-sys
+        run: |
+          cargo init --bin libbpf-rs-test-project
+          cd libbpf-rs-test-project
+          # Add the most recent *published* version of libbpf-rs (as opposed to,
+          # say, cloning a development snapshot, which would just introduce
+          # additional uncertainty into the process).
+          cargo add libbpf-rs
+          # Override libbpf-sys in use with our current one.
+          cat >> Cargo.toml <<EOF
+          [patch.crates-io]
+          libbpf-sys = { path = '..' }
+          EOF
+          cargo build
+
   publish:
     name: Publish to crates.io
     if: github.ref == 'refs/heads/master' && github.ref_type == 'tag'


### PR DESCRIPTION
libbpf-sys aims to adhere to semantic versioning rules and indicate incompatible changes by bumping major version numbers. However, it is sometimes hard to identify breaking changes in advance and so breakage may happen unintentionally. Detecting of such breaking changes also becomes harder with auto-generated code, and libbpf-sys has a bunch of that, owing due to it binding to a C library. For example, in libbpf-rs [0] we have encountered a case where we were relying on a bindgen generated type exported by libbpf-sys that got removed because bindgen changed its behavior, which effectively resulted in a semver violation.

To aid with the detection such unintended incompatibilities, this change adds a CI step that builds the most recent published version of libbpf-rs with the current libbpf-sys snapshot, to flag accidental breakage.

[0] https://github.com/libbpf/libbpf-rs/issues/303

Closes: #53
Signed-off-by: Daniel Müller <deso@posteo.net>