### PR TITLE
Use proper minimum versions of cc and pkg-config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ maintenance = { status = "passively-maintained" }
 
 [build-dependencies]
 bindgen = { version = "^0.63", optional = true }
-cc = "^1.0"
-pkg-config = "^0.3"
+cc = "^1.0.3"
+pkg-config = "^0.3.3"
 
 [lib]
 crate-type = ["lib", "staticlib"]


### PR DESCRIPTION
The version specifications for both `cc` and `pkg-config` are too low. Version `1.0.0` of `cc`, for example, is lacking the `cflags_env()` method [0] entirely and `pkg-config` 0.3.0 fails to compile on stable altogether, requiring nightly features and showing other compile errors. Bump both to the actual minimum supported versions.

[0] https://docs.rs/cc/1.0.78/cc/struct.Tool.html#method.cflags_env

Signed-off-by: Daniel Müller <deso@posteo.net>