### PR TITLE
Only use non-empty paths within LD_LIBRARY_PATH

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -151,7 +151,9 @@ fn main() {
 
     if let Ok(ld_path) = env::var("LD_LIBRARY_PATH") {
         for path in ld_path.split(":") {
-            println!("cargo:rustc-link-search=native={}", path);
+            if !path.is_empty() {
+                println!("cargo:rustc-link-search=native={}", path);
+            }
         }
     }
 }


### PR DESCRIPTION
I had issues building when I had an empty path within LD_LIBRARY_PATH and this seemed like the simplest solution.