### PR TITLE
HOTFIX: elfutils must have the test directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 build = "build.rs"
 links = "libbpf"
 exclude = [
-	"/elfutils/tests",
+	"/elfutils/tests/*.bz2",
 	"/libbpf/assets",
 	"/zlib/contrib",
 ]


### PR DESCRIPTION
Elfutils autoreconf requires the test directory to exist, and configure requires a few files within that directory.  However, the bz2 files are not required.