### PR TITLE
Make novendor feature the default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - rust-target: x86_64-unknown-linux-gnu
             os-target: x86_64-linux-gnu
             os-arch: amd64
-            features: novendor
+            features: static 
 
           - rust-target: aarch64-unknown-linux-gnu
             os-target: aarch64-linux-gnu
@@ -59,8 +59,16 @@ jobs:
               zlib1g-dev:${{ matrix.os-arch }}
 
       - name: Install libbpf-dev
-        if: matrix.features == 'novendor'
         run: sudo apt-get install libbpf-dev:${{ matrix.os-arch }}
+
+      - name: Install Static Compilation dependencies
+        run: |
+          sudo apt-get install \
+              autopoint:${{ matrix.os-arch }} \
+              autoconf:${{ matrix.os-arch }} \
+              flex:${{ matrix.os-arch }} \
+              bison:${{ matrix.os-arch }} \
+              gawk:${{ matrix.os-arch }}
 
       - name: Install linker for ${{ matrix.os-target }}
         if: matrix.os-arch != 'amd64'
@@ -84,7 +92,6 @@ jobs:
       matrix:
         features:
           - ''
-          - novendor
     env:
       CARGO_TERM_VERBOSE: 'true'
     steps:
@@ -105,7 +112,6 @@ jobs:
             zlib-dev
 
       - name: Install libbpf-dev
-        if: matrix.features == 'novendor'
         run: apk add libbpf-dev
         shell: alpine.sh --root {0}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,5 @@ num_cpus = "^1.16.0"
 crate-type = ["lib", "staticlib"]
 
 [features]
-novendor = []
 static = []
-vendored = ["static"]
+novendor = [] # depricated, novendor is the default

--- a/build.rs
+++ b/build.rs
@@ -97,7 +97,7 @@ fn main() {
 
     generate_bindings(src_dir.clone());
 
-    if cfg!(feature = "novendor") {
+    if cfg!(not(feature = "static")) {
         println!("cargo:rustc-link-lib={}bpf\n", library_prefix());
         return;
     }
@@ -107,13 +107,11 @@ fn main() {
     // check for all necessary compilation tools
     pkg_check("make");
     pkg_check("pkg-config");
-    if cfg!(feature = "vendored") {
-        pkg_check("autoreconf");
-        pkg_check("autopoint");
-        pkg_check("flex");
-        pkg_check("bison");
-        pkg_check("gawk");
-    }
+    pkg_check("autoreconf");
+    pkg_check("autopoint");
+    pkg_check("flex");
+    pkg_check("bison");
+    pkg_check("gawk");
 
     let compiler = match cc::Build::new().try_get_compiler() {
         Ok(compiler) => compiler,
@@ -127,9 +125,7 @@ fn main() {
     let _ = fs::create_dir(&obj_dir);
 
     // compile static zlib and static libelf
-    #[cfg(feature = "vendored")]
     make_zlib(&compiler, &src_dir, &out_dir);
-    #[cfg(feature = "vendored")]
     make_elfutils(&compiler, &src_dir, &out_dir);
 
     let cflags = if cfg!(feature = "vendored") {
@@ -187,7 +183,6 @@ fn main() {
     }
 }
 
-#[cfg(feature = "vendored")]
 fn make_zlib(compiler: &cc::Tool, src_dir: &path::PathBuf, out_dir: &path::PathBuf) {
     use nix::fcntl;
     use std::os::fd::AsRawFd;
@@ -232,7 +227,6 @@ fn make_zlib(compiler: &cc::Tool, src_dir: &path::PathBuf, out_dir: &path::PathB
     assert!(status.success(), "make failed");
 }
 
-#[cfg(feature = "vendored")]
 fn make_elfutils(compiler: &cc::Tool, src_dir: &path::PathBuf, out_dir: &path::PathBuf) {
     use nix::fcntl;
     use std::os::fd::AsRawFd;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 include!("bindings.rs");
 
+#[cfg(feature = "static")]
 macro_rules! header {
     ($file:literal) => {
         ($file, include_str!(concat!("../libbpf/src/", $file)))
@@ -15,7 +16,7 @@ macro_rules! header {
 /// Vendored libbpf headers
 ///
 /// Tuple format is: (header filename, header contents)
-#[cfg(not(feature = "novendor"))]
+#[cfg(feature = "static")]
 pub const API_HEADERS: [(&'static str, &'static str); 10] = [
     header!("bpf.h"),
     header!("libbpf.h"),


### PR DESCRIPTION
Make novendor feature the default
Merge vendored feature into static

There is now only two settings
- default (formerly novendor, all libs are dynamic)
- static (formerly vendored, all libs are static)

Side Effect: Clients of libbpf-sys will now compile zlib and elfutils as part of the libbpf-sys project.  This has the benefit of ensuring that the libraries are well suited for the rust bindings, but takes extra time during compilation