### PR TITLE
CI: Run CI workflow on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-on: push
+on:
+  pull_request:
+  push:
 
 jobs:
   test-gnu:


### PR DESCRIPTION
Let's run the CI workflow on pull requests, so that feedback is more immediate (well, to the degree that is possible). The only concern here could be that we now potentially run twice when creating a pull request and then merging it. But that seems like a tiny price to pay. If we were to force pull request creation we could remove running on push, but I am not sure that's worth it.