### PR TITLE
hotfix: static elfutils requires turning off a flag

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -253,6 +253,9 @@ fn make_elfutils(compiler: &cc::Tool, src_dir: &path::PathBuf, out_dir: &path::P
             }
         })
         .collect();
+
+    #[cfg(target_arch = "aarch64")]
+    cflags.push_str(" -Wno-error=stringop-overflow"); 
     cflags.push_str(&format!(" -I{}/zlib/", src_dir.display()));
 
     let status = process::Command::new("autoreconf")


### PR DESCRIPTION
Fix the following error on Arm64
```
  In file included from /usr/include/features.h:490,
                   from /usr/include/libintl.h:23,
                   from ../lib/eu-config.h:55,
                   from ../config.h:206,
                   from elf_begin.c:32:
  In function ‘pread’,
      inlined from ‘pread_retry’ at ../lib/system.h:191:21,
      inlined from ‘read_unmmaped_file’ at elf_begin.c:604:19,
      inlined from ‘read_file’ at elf_begin.c:719:10:
  /usr/include/bits/unistd.h:74:10: error: ‘__pread_alias’ specified size between 9223372036854775809 and 18446744073709551615 exceeds maximum object size 9223372036854775807 [-Werror=stringop-overflow=]
     74 |   return __glibc_fortify (pread, __nbytes, sizeof (char),
        |          ^~~~~~~~~~~~~~~
  elf_begin.c: In function ‘read_file’:
  elf_begin.c:601:5: note: destination object allocated here
    601 |   } mem;
        |     ^~~
  /usr/include/bits/unistd.h:50:16: note: in a call to function ‘__pread_alias’ declared with attribute ‘access (write_only, 2, 3)’
     50 | extern ssize_t __REDIRECT (__pread_alias,
        |                ^~~~~~~~~~
  cc1: all warnings being treated as errors
  make[2]: *** [Makefile:846: elf_begin.o] Error 1
  make[2]: *** Waiting for unfinished jobs....
  make[1]: *** [Makefile:539: install-recursive] Error 1
  thread 'main' panicked at 'make failed', /home/mm/.cargo/git/checkouts/libbpf-sys-c1a3c506327d30bf/ef6ca89/build.rs:298:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
make: *** [Makefile:19: release] Error 101
```