### PR TITLE
CI: Build libbpf-rs-test-project outside of libbpf-sys workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,17 +142,18 @@ jobs:
 
       - name: Build libbpf-rs with libbpf-sys
         run: |
+          dir=$(pwd)
+          cd /tmp/
           cargo init --bin libbpf-rs-test-project
           cd libbpf-rs-test-project
-          # Add the most recent *published* version of libbpf-rs (as opposed to,
-          # say, cloning a development snapshot, which would just introduce
-          # additional uncertainty into the process).
-          cargo add libbpf-rs
-          # Override libbpf-sys in use with our current one.
+          # Add libbpf-rs dependency and override libbpf-sys in use with our
+          # current one.
           cat >> Cargo.toml <<EOF
+          libbpf-rs = "*"
           [patch.crates-io]
-          libbpf-sys = { path = '..' }
+          libbpf-sys = { path = "${dir}" }
           EOF
+          cargo update
           cargo build
 
   publish:


### PR DESCRIPTION
Our libbpf-rs integration workflow fails when invoked on the publish path, because, evidently, Cargo attempts to query the libbpf-sys of an unpublished version from crates.io (or at least that is my reading of it).
Work around this behavior by creating the test project outside of the workspace.