### PR TITLE
elfutils: use https protocol for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/libbpf/libbpf.git
 [submodule "elfutils"]
 	path = elfutils
-	url = git://sourceware.org/git/elfutils.git
+	url = https://sourceware.org/git/elfutils.git
 [submodule "zlib"]
 	path = zlib
 	url = https://github.com/madler/zlib.git


### PR DESCRIPTION
Using git:// protocol for submodules quite often causes issues in corporate setting where development machines are behind firewalls. For http/https usually some transparent proxy would be provided, while git protocol isn't proxied as nicely.

Let's avoid unnecessary complications and use https:// protocol for elfutils submodule.