### PR TITLE
Write bindgen generated bindings to OUT_DIR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,6 @@ static-libelf = ["static-libbpf"]
 # Link zlib statically. Implies linking libbpf statically, because libbpf is
 # the libelf consumer.
 static-zlib = ["static-libbpf"]
+# Generate bindings into source directory, should only be used for local
+# binding source updating. User should use "bindgen" feature flag instead.
+bindgen-source = ["bindgen"]

--- a/build.rs
+++ b/build.rs
@@ -41,6 +41,12 @@ fn generate_bindings(src_dir: path::PathBuf) {
         .collect(),
     );
 
+    #[cfg(feature = "bindgen-source")]
+    let out_dir = &src_dir.join("src");
+    #[cfg(not(feature = "bindgen-source"))]
+    let out_dir =
+        &path::PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR should always be set"));
+
     bindgen::Builder::default()
         .derive_default(true)
         .explicit_padding(true)
@@ -73,7 +79,7 @@ fn generate_bindings(src_dir: path::PathBuf) {
         ))
         .generate()
         .expect("Unable to generate bindings")
-        .write_to_file(&src_dir.join("src/bindings.rs"))
+        .write_to_file(out_dir.join("bindings.rs"))
         .expect("Couldn't write bindings");
 }
 
@@ -254,7 +260,7 @@ fn make_elfutils(compiler: &cc::Tool, src_dir: &path::Path, out_dir: &path::Path
         .collect();
 
     #[cfg(target_arch = "aarch64")]
-    cflags.push_str(" -Wno-error=stringop-overflow"); 
+    cflags.push_str(" -Wno-error=stringop-overflow");
     cflags.push_str(&format!(" -I{}/zlib/", src_dir.display()));
 
     let status = process::Command::new("autoreconf")

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -26,7 +26,7 @@ RUN \
 
 ENTRYPOINT \
 	source $HOME/.cargo/env; \
-	cargo build --features bindgen --release --verbose;
+	cargo build --features bindgen-source --release --verbose;
 EOF
 
 ${DOCKER} run --platform linux/amd64 --rm -v "$(pwd):/usr/local/src/libbpf-sys" libbpf-sys-builder

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+#[cfg(all(feature = "bindgen", not(feature = "bindgen-source")))]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+#[cfg(any(not(feature = "bindgen"), feature = "bindgen-source"))]
 include!("bindings.rs");
 
 #[cfg(feature = "vendored-libbpf")]


### PR DESCRIPTION
libbpf-sys is used as both build dependency and target dependency in a libbpf-cargo project. And when trying to enable bindgen for cross compilation in such project, the generated target-specific bindings would overwrite bundled amd64 bindings, causing libpbf-sys
failed to satisfy its dependents as a build dependency.

Change the behavior of "bindgen" feature to generate bindings into OUT_DIR instead of source directory to address this issue. And migrate the original behavior to "bindgen-source" feature.