### PR TITLE
Switch to using elfutils GitHub mirror for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/libbpf/libbpf.git
 [submodule "elfutils"]
 	path = elfutils
-	url = https://sourceware.org/git/elfutils.git
+	url = https://github.com/libbpf/elfutils-mirror.git
 [submodule "zlib"]
 	path = zlib
 	url = https://github.com/madler/zlib.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,5 +57,5 @@ static-libbpf = []
 # the libelf consumer.
 static-libelf = ["static-libbpf"]
 # Link zlib statically. Implies linking libbpf statically, because libbpf is
-# the libelf consumer.
+# the zlib consumer.
 static-zlib = ["static-libbpf"]


### PR DESCRIPTION
Commit 9ed58f7dd737 ("elfutils: use https protocol for submodule") seems to be causing issues in dependent projects in that it appears as if Cargo, when attempting to clone/update the elfutils git submodule now, fails doing so:
  >     Updating git submodule `https://sourceware.org/git/elfutils.git`
  > warning: spurious network error (3 tries remaining): early EOF; class=Net (12); code=Eof (-20)
  > warning: spurious network error (2 tries remaining): early EOF; class=Net (12); code=Eof (-20)
  > warning: spurious network error (1 tries remaining): early EOF; class=Net (12); code=Eof (-20)
  > error: failed to load source for dependency `libbpf-sys`
  >
  > Caused by:
  >   Unable to update https://github.com/libbpf/libbpf-sys.git?rev=9ed58f7dd737496396b6ea052e771539b3c76e8c
  >
  > Caused by:
  >   failed to update submodule `elfutils`
  >
  > Caused by:
  >   failed to fetch submodule `elfutils` from https://sourceware.org/git/elfutils.git
  >
  > Caused by:
  >   network failure seems to have happened
  >   if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
  >   https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
  >
  > Caused by:
  >   early EOF; class=Net (12); code=Eof (-20)

Presumably, that is because of some peculiarities of sourceware.org's Git-over-HTTP support that libgit2 (which I understand is used by Cargo by default) chokes on -- though a more detailed investigation has not been performed.

The suggested git-fetch-with-cli workaround does the job, but for reasons probably pertaining how Cargo sources config.toml files, such a setting in libbpf-sys itself won't be honored in the dependent repository. That means that each dependent repository would need to enshrine this setting in its own Cargo configuration.

With this change we pull out the big guns and switch to a custom mirror of sourceware's elfutils on GitHub. We already pull all other submodules from GitHub and don't update elfutils all that frequently, so this seems like a reasonable forward.