### PR TITLE
feat: pass extra cflags via LIBBPF_SYS_EXTRA_CFLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ $ git clone --recurse-submodules https://github.com/libbpf/libbpf-sys.git && cd 
 $ cargo build
 ```
 
+#### Environment Variables
+
+- `LIBBPF_SYS_EXTRA_CFLAGS` can be used to pass extra cflags when vendoring libbpf, libz or libelf.
+
 ### Distribution
 
 When you add this crate as a dependency to your project, your resulting binaries will dynamically link with `libz` and `libelf`. This means that the systems where you run your binaries must have these libraries installed.

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,6 @@ use std::process;
 
 use nix::fcntl;
 
-
 fn emit_rerun_directives_for_contents(dir: &Path) {
     for result in read_dir(dir).unwrap() {
         let file = result.unwrap();
@@ -156,7 +155,13 @@ fn main() {
         let compiler = cc::Build::new().try_get_compiler().expect(
             "a C compiler is required to compile libbpf-sys using the vendored copy of libbpf",
         );
-        let cflags = compiler.cflags_env();
+        let mut cflags = compiler.cflags_env();
+        println!("cargo:rerun-if-env-changed=LIBBPF_SYS_EXTRA_CFLAGS");
+        let extra_cflags = env::var_os("LIBBPF_SYS_EXTRA_CFLAGS").unwrap_or_default();
+        if !extra_cflags.is_empty() {
+            cflags.push(" ");
+            cflags.push(extra_cflags);
+        }
         (Some(compiler), cflags)
     } else {
         (None, ffi::OsString::new())

--- a/build.rs
+++ b/build.rs
@@ -157,8 +157,7 @@ fn main() {
         );
         let mut cflags = compiler.cflags_env();
         println!("cargo:rerun-if-env-changed=LIBBPF_SYS_EXTRA_CFLAGS");
-        let extra_cflags = env::var_os("LIBBPF_SYS_EXTRA_CFLAGS").unwrap_or_default();
-        if !extra_cflags.is_empty() {
+        if let Some(extra_cflags) = env::var_os("LIBBPF_SYS_EXTRA_CFLAGS") {
             cflags.push(" ");
             cflags.push(extra_cflags);
         }


### PR DESCRIPTION
Allow downstream users to pass extra compiler flags via `LIBBPF_SYS_EXTRA_CFLAGS` environment variable when vendoring libbpf, libz or libelf.

This could be used to set a custom include path when cross-compiling libbpf-sys. e.g. `LIBBPF_SYS_EXTRA_CFLAGS="-I $(pwd)/aarch64/usr/include"`

