### PR TITLE
Stop abusing LD_LIBRARY_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $ cargo build
 #### Environment Variables
 
 - `LIBBPF_SYS_EXTRA_CFLAGS` can be used to pass extra cflags when vendoring libbpf, libz or libelf.
+- `LIBBPF_SYS_LIBRARY_PATH`: colon separated paths for the linker to find native libs.
 
 ### Distribution
 

--- a/build.rs
+++ b/build.rs
@@ -198,9 +198,9 @@ fn main() {
     );
     println!("cargo:include={}/include", out_dir.to_string_lossy());
 
-    println!("cargo:rerun-if-env-changed=LD_LIBRARY_PATH");
-    if let Ok(ld_path) = env::var("LD_LIBRARY_PATH") {
-        for path in ld_path.split(':') {
+    println!("cargo:rerun-if-env-changed=LIBBPF_SYS_LIBRARY_PATH");
+    if let Ok(lib_path) = env::var("LIBBPF_SYS_LIBRARY_PATH") {
+        for path in lib_path.split(':') {
             if !path.is_empty() {
                 println!("cargo:rustc-link-search=native={}", path);
             }


### PR DESCRIPTION
LD_LIBRARY_PATH is meant for the dynamic linker to search for shared libraries at runtime. Previously libbpf-sys abused this variable to provide pathes for the linker(invoked by rustc) to find libraries at build time. And this is not documented at all.

This commit proposes to use a dedicated enviroment variable for this purpose and documents it in README.md

Fix #50