### PR TITLE
Introduce dedicated publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   pull_request:
   push:
+  workflow_call:
 
 jobs:
   test-gnu:
@@ -182,42 +183,3 @@ jobs:
       - name: Check that C header is up-to-date
         run: git diff --exit-code ||
                (echo "!!!! CHECKED IN C HEADER IS OUTDATED !!!!" && false)
-
-  publish:
-    name: Publish to crates.io
-    if: github.ref == 'refs/heads/master' && github.ref_type == 'tag'
-    needs:
-      - test-gnu
-      - test-musl
-      - test-libbpf-rs
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.rust-target }}
-
-      # This is needed for cargo-pkgid.
-      - name: Fetch dependencies and generate Cargo.lock
-        run: cargo fetch
-
-      - name: Resolve crate version and check git tag name
-        run: |
-          crate_version="$(cargo pkgid | cut -d '#' -f2 | grep -o '[^:]*$')"
-          git_tag=${GITHUB_REF#refs/tags/}
-
-          if [ "$git_tag" != "$crate_version" ]; then
-              printf '::error::%s\n' "Crate version ($crate_version) does not match git tag ($git_tag)"
-              exit 1
-          fi
-
-      - name: Publish to crates.io
-        # no-verify is to skip building; it has been already verified in the test-* jobs.
-        run: cargo publish --no-verify --verbose
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  version:
+    name: Retrieve version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+    - uses: actions/checkout@v4
+    - id: version
+      shell: bash
+      run: |
+        cargo generate-lockfile
+        pkgid="$(cargo pkgid)"
+        # Format is typically
+        #   file://<path>/<crate>#<version>
+        # but could also be along the lines of
+        #   file://<path>/<crate>#<actual-crate-name>@<version>
+        version="$(echo ${pkgid} | cut -d '#' -f2 | cut -d '@' -f2 | grep -o '[^:]*$')"
+        if [ -z "${version}" ]; then
+          echo "Invalid version string: ${pkgid}"
+          exit 1
+        fi
+        echo "Determined crate version: ${version}"
+        echo "version=${version}" >> $GITHUB_OUTPUT
+  test:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+  publish:
+    needs: [test, version]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - name: Dry-run package creation
+      run: cargo package --no-verify
+    - name: Create git tag
+      env:
+        version: ${{ needs.version.outputs.version }}
+      run: |
+        curl --location \
+          --fail-with-body \
+          --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/releases \
+          --header "Accept: application/vnd.github+json" \
+          --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          --header "X-GitHub-Api-Version: 2022-11-28" \
+          --data "{
+              \"tag_name\":\"v${version}\",
+              \"target_commitish\":\"${{ github.ref }}\",
+              \"name\":\"v${version}\",
+              \"draft\":false,
+              \"prerelease\":false,
+              \"generate_release_notes\":false
+            }"
+    - name: Publish
+      run: cargo publish --no-verify --token "${CARGO_REGISTRY_TOKEN}"
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Introduce a dedicated workflow for publishing the crate by push of a button. This is a much nicer experience than having to push a tag, in my opinion, and there is no longer a need for mismatch check. Instead of the user having to create the tag, let GitHub Actions do it for us. Security-wise this reversal shouldn't matter: it's just meta-data attached to a commit, which we can easily verify that it hasn't changed. Because tags did not seem to be signed in past, we are not loosing anything there either by having a some piece of infrastructure do it.