### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    rebase-strategy: auto
+    directory: /
+    schedule:
+      interval: daily
+  - package-ecosystem: cargo
+    versioning-strategy: auto
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Add configuration for Dependabot to automatically update dependencies, if possible. Updates are currently managed to GitHub Actions as well as Cargo.toml based Rust dependencies.