### PR TITLE
Check out all submodules in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - uses: dtolnay/rust-toolchain@stable
     - name: Dry-run package creation
       run: cargo package --no-verify


### PR DESCRIPTION
Make sure to check out all submodules in the publish workflow so that we include all vendored dependencies in the resulting package.