### PR TITLE
Fix links metadata in manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = [
 license = "BSD-2-Clause"
 edition = "2018"
 build = "build.rs"
-links = "libbpf"
+links = "bpf"
 exclude = [
 	"/elfutils/tests/*.bz2",
 	"/libbpf/assets",


### PR DESCRIPTION
The `links` field should not contain the `lib` prefix, as documented in

- https://doc.rust-lang.org/cargo/reference/manifest.html#the-links-field
- https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key