### PR TITLE
Add direct link to documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ description = "Rust bindings to libbpf from the Linux kernel"
 readme = "README.md"
 repository = "https://github.com/libbpf/libbpf-sys"
 homepage = "https://github.com/libbpf/libbpf-sys"
+documentation = "https://docs.rs/libbpf-sys"
 keywords = ["bpf", "ebpf", "xdp"]
 authors = [
 	"Alex Forster <alex@alexforster.com>",


### PR DESCRIPTION
Make the URL to the documentation of the library crate known so that it will be easier to click through to it from a crates.io search.