### PR TITLE
chore: Generate bindings based upon `rust-version`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = [
 	"Daniel Xu <dxu@dxuuu.xyz>",
 ]
 license = "BSD-2-Clause"
-edition = "2024"
+edition = "2021"
 rust-version = "1.82"
 build = "build.rs"
 links = "bpf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ authors = [
 	"Daniel Xu <dxu@dxuuu.xyz>",
 ]
 license = "BSD-2-Clause"
-edition = "2018"
+edition = "2024"
+rust-version = "1.82"
 build = "build.rs"
 links = "bpf"
 exclude = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 license = "BSD-2-Clause"
 edition = "2021"
-rust-version = "1.82"
+rust-version = "1.82" # first stable release to support "unsafe extern"
 build = "build.rs"
 links = "bpf"
 exclude = [

--- a/build.rs
+++ b/build.rs
@@ -58,6 +58,7 @@ fn generate_bindings(src_dir: path::PathBuf) {
         &path::PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR should always be set"));
 
     bindgen::Builder::default()
+        .rust_target(env!("CARGO_PKG_RUST_VERSION").parse().expect("valid"))
         .derive_default(true)
         .explicit_padding(true)
         .default_enum_style(bindgen::EnumVariation::Consts)

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -5,7 +5,7 @@ DOCKER="docker"
 set -eu -o pipefail
 
 ${DOCKER} build --platform linux/amd64 -t libbpf-sys-builder - <<'EOF'
-FROM ubuntu:jammy AS libbpf-sys-builder
+FROM ubuntu:latest AS libbpf-sys-builder
 
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
@@ -26,7 +26,7 @@ RUN \
 
 ENTRYPOINT \
 	source $HOME/.cargo/env; \
-	cargo build --features bindgen-source --release --verbose;
+	cargo check --features bindgen-source --verbose;
 EOF
 
 ${DOCKER} run --platform linux/amd64 --rm -v "$(pwd):/usr/local/src/libbpf-sys" libbpf-sys-builder

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -49,7 +49,11 @@ where
             index % 8
         };
         let mask = 1 << bit_index;
-        if val { byte | mask } else { byte & !mask }
+        if val {
+            byte | mask
+        } else {
+            byte & !mask
+        }
     }
     #[inline]
     pub fn set_bit(&mut self, index: usize, val: bool) {
@@ -7422,7 +7426,7 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn btf__add_ptr(btf: *mut btf, ref_type_id: ::std::os::raw::c_int)
-    -> ::std::os::raw::c_int;
+        -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn btf__add_array(
@@ -8426,7 +8430,7 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn bpf_map__reuse_fd(map: *mut bpf_map, fd: ::std::os::raw::c_int)
-    -> ::std::os::raw::c_int;
+        -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn bpf_map__name(map: *const bpf_map) -> *const ::std::os::raw::c_char;
@@ -8442,7 +8446,7 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn bpf_map__set_max_entries(map: *mut bpf_map, max_entries: __u32)
-    -> ::std::os::raw::c_int;
+        -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn bpf_map__map_flags(map: *const bpf_map) -> __u32;
@@ -8681,7 +8685,7 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn bpf_tc_attach(hook: *const bpf_tc_hook, opts: *mut bpf_tc_opts)
-    -> ::std::os::raw::c_int;
+        -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn bpf_tc_detach(
@@ -8890,7 +8894,7 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn perf_buffer__buffer_fd(pb: *const perf_buffer, buf_idx: size_t)
-    -> ::std::os::raw::c_int;
+        -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn perf_buffer__buffer(


### PR DESCRIPTION
**TL;DR:**
- Rust 1.82 (Oct 2024) is required to build the crate, encode that information into `Cargo.toml`. This benefits users and the cargo resolver going forward.
- Consider bumping `edition` to `2021` given the minimum version of rust is well beyond `1.56`?

**UPDATE:** [As later discussed](https://github.com/libbpf/libbpf-sys/pull/124#issuecomment-3014789119), prior to this PR bindings were generated for the [latest Rust toolchain](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.rust_target), whereas this PR has been adjusted to lower that to permit building on Rust prior to 1.82.

---

Required for bindings change to `unsafe extern`:
- [This PR](https://github.com/libbpf/libbpf-sys/pull/113) from Dec 2024 bumped bindgen version, and committed a change to use `unsafe extern` (_introduced with [Rust 1.82 in Oct 2024](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0/#safe-items-with-unsafe-extern)_).
- Unfortunately this change was part of the [`1.5.1` release of `libbpf-sys`](https://github.com/libbpf/libbpf-sys/releases/tag/v1.5.1%2Bv1.5.1) (May 2025), so anyone using the [Nov 2024 `1.5.0` release](https://github.com/libbpf/libbpf-sys/releases/tag/v1.5.0%2Bv1.5.0) (_without explicitly pinning it_) has had their minimum required Rust also bumped.
- Not only is [`rust-version`](https://doc.rust-lang.org/cargo/reference/rust-version.html) helpful at communicating this information to the resolver, users will not need to troubleshoot the build failure to identify the minimum Rust toolchain required.

On Rust toolchains prior to 1.82, builds for `libbpf-sys@1.5.1` would fail with the following:

```rust
error: extern block cannot be declared unsafe
    --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libbpf-sys-1.5.1+v1.5.1/src/bindings.rs:9168:1
     |
9168 | unsafe extern "C" {
     | ^^^^^^
     |
     = note: see issue #123743 <https://github.com/rust-lang/rust/issues/123743> for more information
```

**NOTE:** Feb 2025 released [Rust 1.85 which introduced the Rust 2024 edition](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/#rust-2024). There's technically no need to raise the version of rust required to 1.85, but bumping the [rust edition](https://doc.rust-lang.org/edition-guide/editions/) to 2024 this may be required AFAIK (_and [may require some additional work](https://codeandbitters.com/rust-2024-upgrade/)_). Given [Rust 2021 edition was from Oct 2021 with Rust 1.56.0](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0/) and the required `rust-version` to build this crate, you might as well consider bumping that though?

---

I have not contributed a CI update, but ideally you would run tests for your minimum supported rust version to catch these sort of implicit bumps.
- Technically bindgen crate should probably have this themselves, as once `rust-version` is configured for a crate, the resolver should be able to fallback to earlier releases (_when semver constraint is compatible_).
- Since this is the first time `rust-version` is added to `Cargo.toml` here, falling back to `1.5.1` as the prior release will of course still expect Rust 1.82, but if it had been configured for that release instead, the fallback to `1.5.0` would have worked.